### PR TITLE
Many assorted updates to exercise 8 code

### DIFF
--- a/exercises/exercise8.py
+++ b/exercises/exercise8.py
@@ -12,15 +12,16 @@ NUMBER_OF_REPLICAS = 3
 # if you need repetition:
 # random.seed(100)
 
+
 class GfsMaster(Device):
     def __init__(self, index: int, number_of_devices: int, medium: Medium):
         super().__init__(index, number_of_devices, medium)
-        self._metadata = {}
-        self.chunks_being_allocated = []
+        self._metadata: dict[tuple[str, int], tuple[int, list[int]]] = {}  # (filename, chunk_index) -> (chunkhandle, [chunkservers])
+        self.chunks_being_allocated: list[tuple[int, int]] = []  # [(chunkhandle, requester_index)]
         GfsNetwork.gfsmaster.append(index)
 
     def run(self):
-        # since this is a server, its job is to answer for requests (messages), then do something
+        # since this is a server, its job is to wait for requests (messages), then do something
         while True:
             for ingoing in self.medium().receive_all():
                 if not self.handle_ingoing(ingoing):
@@ -32,69 +33,61 @@ class GfsMaster(Device):
             key = (ingoing.filename, ingoing.chunkindex)
             chunk = self._metadata.get(key)
             if chunk is not None:
-
                 for c in self.chunks_being_allocated:
                     if c[0] == chunk[0]:
                         self.chunks_being_allocated.append((chunk[0], ingoing.source))
                         return True
-                        
-
-                anwser = File2ChunkRspMessage(
+                answer = File2ChunkRspMessage(
                     self.index(),
                     ingoing.source,
                     chunk[0],
                     chunk[1]
                     )
-                self.medium().send(anwser)
+                self.medium().send(answer)
             else:
                 if ingoing.createIfNotExists:
                     self.do_allocate_request(ingoing.filename, ingoing.chunkindex, ingoing.source)
                 else:
-                    anwser = File2ChunkRspMessage(
+                    answer = File2ChunkRspMessage(
                         self.index(),
                         ingoing.source,
                         0,
                         []
                         )
-                    self.medium().send(anwser)
+                    self.medium().send(answer)
         elif isinstance(ingoing, QuitMessage):
-            print("I am Master " + str(self.index()) + " and I am quitting")
+            print(f"I am Master {self.index()} and I am quitting")
             return False
         elif isinstance(ingoing, AllocateChunkRspMessage):
-            if not ingoing.result == "ok":
-                print("allocation failed! I am quitting!!")
+            if ingoing.result != "ok":
+                print("Allocation failed! I am quitting!!")
                 return False
             for chunk in self._metadata.values():
                 if chunk[0] == ingoing.chunkhandle:
                     self.add_chunk_to_metadata(chunk, ingoing.source)
         return True
 
-    def add_chunk_to_metadata(self, chunk, chunkserver):
+    def add_chunk_to_metadata(self, chunk: tuple[int, list[int]], chunkserver: int):
         chunk[1].append(chunkserver)
         if len(chunk[1]) == NUMBER_OF_REPLICAS:
-            for request in self.chunks_being_allocated:
-                if request[0] == chunk[0]:
-                    anwser = File2ChunkRspMessage(
-                        self.index(),
-                        request[1],
-                        chunk[0],
-                        chunk[1]
-                        )
-                    self.medium().send(anwser)
-    
+            requests = [request for request in self.chunks_being_allocated if request[0] == chunk[0]]
+            for request in requests:
+                answer = File2ChunkRspMessage(
+                    self.index(),
+                    request[1],
+                    chunk[0],
+                    chunk[1]
+                    )
+                self.medium().send(answer)
+                self.chunks_being_allocated.remove(request)
 
-    def do_allocate_request(self, filename, chunkindex, requester):
+    def do_allocate_request(self, filename, chunkindex: int, requester: int):
         chunkhandle = random.randint(0, 999999)
         self.chunks_being_allocated.append((chunkhandle, requester))
         self._metadata[(filename, chunkindex)] = (chunkhandle, [])
 
-        chunkservers = []
-        startnumber = random.randint(0, 9999)
-        for i in range(NUMBER_OF_REPLICAS):
-            numChunkServer = len(GfsNetwork.gfschunkserver)
-            chosen = GfsNetwork.gfschunkserver[(startnumber + i ) % numChunkServer]
-            chunkservers.append(chosen)
-
+        # Allocate the new chunk on "NUMBER_OF_REPLICAS" random chunkservers
+        chunkservers = random.sample(GfsNetwork.gfschunkserver, NUMBER_OF_REPLICAS)
         for i in chunkservers:
             message = AllocateChunkReqMessage(self.index(), i, chunkhandle, chunkservers)
             self.medium().send(message)
@@ -107,9 +100,9 @@ class GfsChunkserver(Device):
     def __init__(self, index: int, number_of_devices: int, medium: Medium):
         super().__init__(index, number_of_devices, medium)
         GfsNetwork.gfschunkserver.append(index)
-        self.localchunks = {}
+        self.localchunks: dict[int, str] = {}  # chunkhandle -> contents
         # the first server in chunkservers is the primary
-        self.chunkservers = {}
+        self.chunkservers: dict[int, list[int]] = {}  # chunkhandle -> [chunkservers]
 
     def run(self):
         # since this is a server, its job is to answer for requests (messages), then do something
@@ -121,7 +114,7 @@ class GfsChunkserver(Device):
 
     def handle_ingoing(self, ingoing: MessageStub):
         if isinstance(ingoing, QuitMessage):
-            print("I am Chunk Server " + str(self.index()) + " and I am quitting")
+            print(f"I am Chunk Server {self.index()} and I am quitting")
             return False
         elif isinstance(ingoing, AllocateChunkReqMessage):
             self.do_allocate_chunk(ingoing.chunkhandle, ingoing.chunkservers)
@@ -129,32 +122,29 @@ class GfsChunkserver(Device):
             self.medium().send(message)
         elif isinstance(ingoing, RecordAppendReqMessage):
             #
-            # TODO: need to implement the storate operation
-            # do not forget the passive replication discipline
+            # TODO: need to implement the storage operation
+            #  do not forget the passive replication discipline
             #
             pass
         return True
 
-    def do_allocate_chunk(self, chunkhandle, servers):
+    def do_allocate_chunk(self, chunkhandle: int, servers: list[int]):
         self.localchunks[chunkhandle] = ""
         self.chunkservers[chunkhandle] = servers
 
     def print_result(self):
         print("chunk server quit. Currently, my saved chunks are as follows:")
-        for c in self.localchunks:
-            print("chunk " + str(c) + " : " + str(self.localchunks[c]))
+        for (chunkhandle, contents) in self.localchunks:
+            print(f"chunk {chunkhandle} : {contents}")
 
 
 class GfsClient(Device):
     def __init__(self, index: int, number_of_devices: int, medium: Medium):
         super().__init__(index, number_of_devices, medium)
-        if index == 0:
-            for i in range(5):
-                pass
 
     def run(self):
-        # being a client, it listens to incoming messags, but it also does something to put the ball rolling
-        print("i am client " + str(self.index()))
+        # being a client, it listens to incoming messages, but it also does something to put the ball rolling
+        print(f"I am Client {self.index()}")
         master = GfsNetwork.gfsmaster[0]
         message = File2ChunkReqMessage(self.index(), master, "myfile.txt", 0, True)
         self.medium().send(message)
@@ -167,13 +157,12 @@ class GfsClient(Device):
 
     def handle_ingoing(self, ingoing: MessageStub):
         if isinstance(ingoing, File2ChunkRspMessage):
-            print("I found out where my chunk is: " + str(ingoing.chunkhandle) + " locations: " + str(ingoing.locations))
+            print(f"I found out where my chunk is: {ingoing.chunkhandle}, locations: {ingoing.locations}")
 
             # I select a random chunk server, and I send the append request
             # I do not necessarily select the primary
-
-            randomserver = ingoing.locations[random.randint(0,999)%len(ingoing.locations)]
-            data = "hello from client number " + str(self.index()) + "\n"
+            randomserver = random.choice(ingoing.locations)
+            data = f"hello from client number {self.index()}\n"
             self.medium().send(RecordAppendReqMessage(self.index(), randomserver, ingoing.chunkhandle, data))
         elif isinstance(ingoing, RecordAppendRspMessage):
             # project completed, time to quit
@@ -181,13 +170,11 @@ class GfsClient(Device):
                 self.medium().send(QuitMessage(self.index(), i))
             for i in GfsNetwork.gfschunkserver:
                 self.medium().send(QuitMessage(self.index(), i))
-
             return False
         return True
 
     def print_result(self):
         pass
-
 
 
 class GfsNetwork:
@@ -203,15 +190,12 @@ class GfsNetwork:
 
 
 
-
 class QuitMessage(MessageStub):
     def __init__(self, sender: int, destination: int):
         super().__init__(sender, destination)
 
     def __str__(self):
         return f'QUIT REQUEST {self.source} -> {self.destination}'
-
-
 
 class File2ChunkReqMessage(MessageStub):
     def __init__(self, sender: int, destination: int, filename: str, chunkindex: int, createIfNotExists = False):
@@ -232,9 +216,8 @@ class File2ChunkRspMessage(MessageStub):
     def __str__(self):
         return f'FILE2CHUNK RESPONSE {self.source} -> {self.destination}: ({self.chunkhandle}, {self.locations})'
 
-
 class AllocateChunkReqMessage(MessageStub):
-    def __init__(self, sender: int, destination: int, chunkhandle: int, chunkservers: list):
+    def __init__(self, sender: int, destination: int, chunkhandle: int, chunkservers: list[int]):
         super().__init__(sender, destination)
         self.chunkhandle = chunkhandle
         self.chunkservers = chunkservers
@@ -267,5 +250,5 @@ class RecordAppendRspMessage(MessageStub):
         # TODO: possibly, complete this message with the fields you need
 
     def __str__(self):
-        return f'RECORD APPEND REQUEST {self.source} -> {self.destination}: ({self.result})'
+        return f'RECORD APPEND RESPONSE {self.source} -> {self.destination}: ({self.result})'
 


### PR DESCRIPTION
Notable suggestions/updates:
- _Added:_ type-hints to function parameters and the more complex local variables (e.g. `self._metadata`).
- _Fixed:_ `GfsMaster.add_chunk_to_metadata()` never removed completed requests from `GfsMaster.chunks_being_allocated`, meaning, the master would always think that all chunks are being allocated.
- _Changed:_ `GfsMaster.do_allocate_request()` selects `NUMBER_OF_REPLICAS` random chunk servers. I compressed this selection into `random.sample(GfsNetwork.gfschunkserver, NUMBER_OF_REPLICAS)`.

Small updates:
- Spelling.
- Formatting.
- Shorthand-syntax for simpler reading.